### PR TITLE
Props graph syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 
 node_modules
 dist
+
+test.js

--- a/src/clients/bucket/lib/methodChaining.ts
+++ b/src/clients/bucket/lib/methodChaining.ts
@@ -6,16 +6,48 @@ export default class MethodChaining {
   }
 
   props(props: string | Array<string>) {
-    let propStr = props;
-    if (Array.isArray(propStr)) {
-      propStr = propStr
-        .filter((prop) => typeof prop === 'string')
+    let propStr: string;
+
+    if (typeof props === 'string') {
+      propStr =
+        props.startsWith('{') && props.endsWith('}')
+          ? this.parseGraphQLProps(props.slice(1, -1))
+          : props;
+    } else if (Array.isArray(props)) {
+      propStr = props
+        .filter((prop): prop is string => typeof prop === 'string')
         .map((prop) => prop.trim())
-        .filter((prop) => !!prop)
-        .toString();
+        .filter(Boolean)
+        .join(',');
+    } else {
+      throw new Error('Invalid props type');
     }
-    this.endpoint += `&props=${propStr}`;
+    this.endpoint += `&props=${encodeURIComponent(propStr)}`;
     return this;
+  }
+
+  private parseGraphQLProps(propsString: string): string {
+    const lines = propsString
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const result: string[] = [];
+    const currentPath: string[] = [];
+
+    for (const line of lines) {
+      if (line.includes('{')) {
+        const [key] = line.split('{');
+        if (key !== undefined) {
+          currentPath.push(key.trim());
+        }
+      } else if (line === '}') {
+        currentPath.pop();
+      } else {
+        result.push([...currentPath, line].join('.'));
+      }
+    }
+
+    return result.join(',');
   }
 
   sort(sort: string) {

--- a/src/clients/bucket/media/index.ts
+++ b/src/clients/bucket/media/index.ts
@@ -48,9 +48,6 @@ export const mediaChainMethods = (
     if (params.metadata) {
       data.append('metadata', JSON.stringify(params.metadata));
     }
-    if (params.alt_text) {
-      data.append('alt_text', params.alt_text);
-    }
     if (params.trigger_webhook) {
       data.append('trigger_webhook', params.trigger_webhook.toString());
     }

--- a/src/types/media.types.ts
+++ b/src/types/media.types.ts
@@ -3,7 +3,6 @@ import { GenericObject } from './generic.types';
 export type InsertMediaType = {
   media: any;
   folder?: string;
-  alt_text?: string;
   metadata?: GenericObject;
   trigger_webhook?: boolean;
 };


### PR DESCRIPTION
As a user, I want to be able to use props more efficiently, currently it’s cumbersome and confusing for deeply nested props. For context on props, see the [Cosmic docs for fetching Objects](https://www.cosmicjs.com/docs/api/objects#get-objects). For example:

This is not ideal:

```jsx
const props = 'slug,title,created_at,metadata.author.title,metadata.author.metadata.favorite_places.title,metadata.author.metadata.favorite_places.metadata.image.url,metadata.vehicle.title,metadata.vehicle.created_at,metadata.vehicle.metadata.image.url'

const { object } = await cosmic.objects.findOne({
  type: "articles",
  slug: "lets-goo"
}).props(props)
.depth(3)
```

It would be better to have something like this:

```jsx
const props = `{
  slug
  title
  created_at
  metadata {
    author {
      title
      metadata {
        favorite_places {
          title
          metadata {
            image {
              url
            }
          }
        }
      }
    }
    vehicle {
      title
      created_at
      metadata {
        image {
          url
        }
      }
    }
  }
}`

const { object } = await cosmic.objects.findOne({
  type: "articles",
  slug: "lets-goo"
}).props(props).depth(3)
```

This will give you the explicit shape of the data payload.