### PR TITLE
feat(rich-text): introduce framework-agnostic HTML renderer and edita…

### DIFF
--- a/.changeset/rich-text-editable-and-html.md
+++ b/.changeset/rich-text-editable-and-html.md
@@ -1,0 +1,5 @@
+---
+"@cosmicjs/rich-text": minor
+---
+
+Add a framework-agnostic `renderToHtml` string renderer via the new `@cosmicjs/rich-text/html` entry point (no React dependency) for use in Vue, Svelte, Astro, and server templates. Also support editable ("Edit on page") blocks: paired `{{name}}...{{/name}}` tokens render their inline content instead of the block definition.

--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -1,10 +1,11 @@
 # @cosmicjs/rich-text
 
-Official React renderer for Cosmic `rich-text` metafields. Rich-text values are
-stored as markdown prose interleaved with `{{shortcode}}` block tokens. Each
-block is a reusable content snippet defined in your bucket settings. This package
-parses the value, resolves blocks against their definitions, and renders to
-React, with an overridable component per block.
+Official renderer for Cosmic `rich-text` metafields. Rich-text values are stored
+as markdown prose interleaved with `{{shortcode}}` block tokens. Each block is
+either a reusable snippet defined in your bucket settings (synced) or an editable
+per-instance copy. This package parses the value, resolves blocks against their
+definitions, and renders to React with an overridable component per block, or to
+a plain HTML string via the React-free `@cosmicjs/rich-text/html` entry point.
 
 ## Install
 
@@ -46,7 +47,8 @@ const Callout = ({ contentHtml }: BlockProps) => (
 ```
 
 Each component receives `{ name, definition, contentHtml }`, where `contentHtml`
-is the block's content already rendered to HTML (markdown or plain text).
+is the block's content already rendered to HTML: the inline content for an
+editable instance, or the definition's content for a synced reference.
 
 ### Inline object embeds
 
@@ -91,6 +93,28 @@ import { renderRichText } from '@cosmicjs/rich-text';
 const nodes = renderRichText(value, { blocks });
 ```
 
+### Render to an HTML string (no React)
+
+For non-React stacks (Vue, Svelte, Astro, server templates), import
+`renderToHtml` from the `@cosmicjs/rich-text/html` entry point, which has no
+React dependency. It returns a single HTML string.
+
+```ts
+import { renderToHtml } from '@cosmicjs/rich-text/html';
+
+const html = renderToHtml(value, {
+  blocks,
+  // Optional: customize block markup.
+  blockWrapper: ({ name, innerHtml }) =>
+    `<aside class="block block-${name}">${innerHtml}</aside>`,
+  // Optional: resolve inline object embeds to your own HTML.
+  resolveObjectHtml: ({ id }) => byId.get(id)?.html,
+});
+```
+
+By default blocks render to the same `data-block` wrapper as the React renderer,
+and unresolved object embeds render to a `data-object` placeholder.
+
 ## Block definitions
 
 A block definition has this shape (stored in `settings.content_blocks`):
@@ -108,13 +132,17 @@ interface BlockDefinition {
 ## Shortcode grammar
 
 ```
-{{ name /}}                                  block reference
+{{ name /}}                                      synced block reference
+{{ name }}...{{/ name }}                          editable ("Edit on page") instance
 {{ object type="posts" id="..." slug="..." /}}   inline object embed
 ```
 
-Blocks reference content by name; the content lives in the block definition.
-Unknown blocks (no matching definition) are dropped unless `keepUnknown` is set.
-The `object` (and `objects`) names are reserved for inline object embeds.
+A synced reference (`{{ name /}}`) resolves its content from the block
+definition, so editing the saved block updates every synced instance. An
+editable instance (`{{ name }}...{{/ name }}`) stores its content inline, so it
+is unique to that value and no longer tracks the saved block. Unknown blocks (no
+matching definition) are dropped unless `keepUnknown` is set. The `object` (and
+`objects`) names are reserved for inline object embeds.
 
 ## Fetching block definitions
 

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -1,18 +1,31 @@
 {
   "name": "@cosmicjs/rich-text",
-  "version": "0.1.0",
-  "description": "Official React renderer for Cosmic rich-text (markdown + shortcode blocks and inline object embeds).",
+  "version": "0.2.0",
+  "description": "Official renderer for Cosmic rich-text (markdown + shortcode blocks and inline object embeds): React components plus a framework-agnostic HTML string renderer.",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./html": {
+      "types": "./dist/html.d.ts",
+      "import": "./dist/html.mjs",
+      "require": "./dist/html.js"
+    }
+  },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --external react",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --external react --watch",
+    "build": "tsup src/index.ts src/html.ts --format cjs,esm --dts --external react",
+    "dev": "tsup src/index.ts src/html.ts --format cjs,esm --dts --external react --watch",
     "check-types": "tsc --noEmit",
+    "test": "npm run build && node --test",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/packages/rich-text/src/RichText.tsx
+++ b/packages/rich-text/src/RichText.tsx
@@ -108,14 +108,19 @@ export function renderRichText(
     }
 
     const definition = definitions.get(segment.name);
-    if (!definition) {
+
+    // A paired block ({{name}}...{{/name}}) is a detached "Edit on page"
+    // instance: its content lives inline in the value, not in the block
+    // definition. Render that inline content (markdown). A self-closing
+    // {{name /}} is a synced reference resolved from the definition.
+    let contentHtml: string;
+    if (segment.paired) {
+      contentHtml = renderMarkdown(segment.content || '');
+    } else if (!definition) {
       return keepUnknown ? (
         <React.Fragment key={index}>{segment.raw}</React.Fragment>
       ) : null;
-    }
-
-    let contentHtml: string;
-    if (definition.editor === 'plain') {
+    } else if (definition.editor === 'plain') {
       contentHtml = plainContentToHtml(definition.content);
     } else if (definition.editor === 'html') {
       // Raw HTML blocks render verbatim. Enable the `sanitize` option (or pass a
@@ -127,7 +132,12 @@ export function renderRichText(
 
     const Component =
       (components && components[segment.name]) || DefaultBlock;
-    const props: BlockProps = { name: segment.name, definition, contentHtml };
+    const props: BlockProps = {
+      name: segment.name,
+      definition,
+      contentHtml,
+      attrs: segment.attrs,
+    };
     return <Component key={index} {...props} />;
   });
 }

--- a/packages/rich-text/src/blockContent.ts
+++ b/packages/rich-text/src/blockContent.ts
@@ -1,0 +1,29 @@
+/**
+ * React-free block primitives shared by the React renderer ({@link ./blocks})
+ * and the framework-agnostic string renderer ({@link ./renderToHtml}). Keeping
+ * these here (with no `react` import) lets the `@cosmicjs/rich-text/html` entry
+ * point be consumed without React installed.
+ */
+
+/**
+ * A reusable Rich Text block definition, as stored in a bucket's
+ * `settings.content_blocks`. Inserting `{{name /}}` in a rich-text value
+ * expands to this block's content.
+ */
+export interface BlockDefinition {
+  name: string;
+  title?: string;
+  description?: string;
+  content: string;
+  editor: 'rich-text' | 'plain' | 'html';
+}
+
+/** Escape plain-text block content, preserving line breaks. */
+export function plainContentToHtml(content: string): string {
+  return String(content || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/\r?\n/g, '<br>');
+}

--- a/packages/rich-text/src/blocks.tsx
+++ b/packages/rich-text/src/blocks.tsx
@@ -1,17 +1,9 @@
 import * as React from 'react';
+import { ShortcodeAttrs } from './shortcode';
+import { BlockDefinition, plainContentToHtml } from './blockContent';
 
-/**
- * A reusable Rich Text block definition, as stored in a bucket's
- * `settings.content_blocks`. Inserting `{{name /}}` in a rich-text value
- * expands to this block's content.
- */
-export interface BlockDefinition {
-  name: string;
-  title?: string;
-  description?: string;
-  content: string;
-  editor: 'rich-text' | 'plain' | 'html';
-}
+export type { BlockDefinition };
+export { plainContentToHtml };
 
 export interface BlockProps {
   /** The block name, e.g. "callout". */
@@ -20,6 +12,11 @@ export interface BlockProps {
   definition?: BlockDefinition;
   /** The block's rendered content HTML. */
   contentHtml: string;
+  /**
+   * Attributes parsed from the shortcode token, e.g. `{{callout type="warning"}}`
+   * yields `{ type: 'warning' }`. Empty for plain `{{callout /}}` references.
+   */
+  attrs?: ShortcodeAttrs;
 }
 
 export type BlockComponents = Record<string, React.ComponentType<BlockProps>>;
@@ -66,16 +63,6 @@ export const DefaultObjectBlock = ({ id, type, slug }: ObjectBlockProps) => (
     {slug || id}
   </div>
 );
-
-/** Escape plain-text block content, preserving line breaks. */
-export function plainContentToHtml(content: string): string {
-  return String(content || '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/\r?\n/g, '<br>');
-}
 
 /** Default block renderer: wraps the rendered content in a data-block div. */
 export const DefaultBlock = ({ name, contentHtml }: BlockProps) => (

--- a/packages/rich-text/src/html.ts
+++ b/packages/rich-text/src/html.ts
@@ -1,0 +1,23 @@
+/**
+ * Framework-agnostic entry point: `@cosmicjs/rich-text/html`.
+ *
+ * Exposes the HTML string renderer and shortcode parser with no React
+ * dependency, for use in Vue, Svelte, Astro, server templates, or any non-React
+ * stack. For React, import from the package root instead.
+ */
+
+export { renderToHtml } from './renderToHtml';
+export type {
+  RenderToHtmlOptions,
+  BlockWrapperArgs,
+  ObjectRef,
+} from './renderToHtml';
+export { plainContentToHtml } from './blockContent';
+export type { BlockDefinition } from './blockContent';
+export { parseShortcodes } from './shortcode';
+export type {
+  Segment,
+  ShortcodeToken,
+  TextSegment,
+  ShortcodeAttrs,
+} from './shortcode';

--- a/packages/rich-text/src/index.ts
+++ b/packages/rich-text/src/index.ts
@@ -1,5 +1,11 @@
 export { renderRichText, RichText } from './RichText';
 export type { RenderRichTextOptions, RichTextProps } from './RichText';
+export { renderToHtml } from './renderToHtml';
+export type {
+  RenderToHtmlOptions,
+  BlockWrapperArgs,
+  ObjectRef,
+} from './renderToHtml';
 export { DefaultBlock, DefaultObjectBlock, plainContentToHtml } from './blocks';
 export type {
   BlockComponents,

--- a/packages/rich-text/src/renderToHtml.ts
+++ b/packages/rich-text/src/renderToHtml.ts
@@ -1,0 +1,147 @@
+import { marked } from 'marked';
+import { parseShortcodes, ShortcodeAttrs } from './shortcode';
+import { BlockDefinition, plainContentToHtml } from './blockContent';
+
+/**
+ * Framework-agnostic renderer: turns a Cosmic rich-text value (markdown +
+ * {{shortcode}} tokens) into a single HTML string. Use this in non-React stacks
+ * (Vue, Svelte, Astro, plain server templates) where {@link renderRichText} (a
+ * React renderer) is not appropriate.
+ *
+ * Resolution mirrors the React renderer:
+ *   - prose            -> markdown rendered to HTML
+ *   - {{name /}}       -> synced reference, content resolved from the block
+ *                         definition (bucket settings)
+ *   - {{name}}...{{/}} -> detached "Edit on page" instance, inline content
+ *                         rendered as markdown
+ *   - {{object ... /}} -> resolved via `resolveObjectHtml`, else a placeholder
+ */
+
+marked.setOptions({ gfm: true, breaks: false });
+
+const renderMarkdownDefault = (md: string): string =>
+  md ? (marked.parse(md, { async: false }) as string) : '';
+
+export interface ObjectRef {
+  id: string;
+  type?: string;
+  slug?: string;
+}
+
+export interface BlockWrapperArgs {
+  name: string;
+  innerHtml: string;
+  definition?: BlockDefinition;
+  attrs: ShortcodeAttrs;
+}
+
+export interface RenderToHtmlOptions {
+  /**
+   * Block definitions from the bucket's settings (`content_blocks`). Used to
+   * resolve synced `{{name /}}` references. Detached (paired) blocks do not
+   * need a definition since their content is inline.
+   */
+  blocks?: BlockDefinition[];
+  /** Custom markdown renderer for prose and block content. Defaults to marked. */
+  renderMarkdown?: (markdown: string) => string;
+  /**
+   * Render an inline object embed ({{object ...}}) to an HTML string. Return
+   * undefined to fall back to the default `data-object` placeholder.
+   */
+  resolveObjectHtml?: (ref: ObjectRef) => string | undefined;
+  /**
+   * Wrap a block's inner HTML. Defaults to the canonical
+   * `<div class="cosmic-block cosmic-block-{name}" data-block="{name}">`.
+   */
+  blockWrapper?: (args: BlockWrapperArgs) => string;
+  /**
+   * Keep unknown blocks (no matching definition) as their raw token instead of
+   * dropping them. Defaults to true so content is never silently lost.
+   */
+  keepUnknown?: boolean;
+}
+
+/** Escape a string for use as text content or a double-quoted attribute value. */
+function escapeHtml(value: string): string {
+  return String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function defaultBlockWrapper({ name, innerHtml }: BlockWrapperArgs): string {
+  const cls = escapeHtml(name);
+  return `<div class="cosmic-block cosmic-block-${cls}" data-block="${cls}">${innerHtml}</div>`;
+}
+
+function defaultObjectHtml(ref: ObjectRef): string {
+  return `<div class="cosmic-object" data-object="${escapeHtml(
+    ref.id
+  )}" data-object-type="${escapeHtml(ref.type || '')}">${escapeHtml(
+    ref.slug || ref.id
+  )}</div>`;
+}
+
+/**
+ * Render a Cosmic rich-text value to an HTML string.
+ */
+export function renderToHtml(
+  value: string,
+  options: RenderToHtmlOptions = {}
+): string {
+  const {
+    blocks = [],
+    renderMarkdown = renderMarkdownDefault,
+    resolveObjectHtml,
+    blockWrapper = defaultBlockWrapper,
+    keepUnknown = true,
+  } = options;
+
+  const definitions = new Map<string, BlockDefinition>();
+  for (const block of blocks) definitions.set(block.name, block);
+
+  const segments = parseShortcodes(value || '');
+
+  return segments
+    .map((segment) => {
+      if (segment.type === 'text') {
+        return renderMarkdown(segment.value);
+      }
+
+      // Inline object embeds reference a live Cosmic Object, not a bucket block.
+      if (segment.name === 'object') {
+        const ref: ObjectRef = {
+          id: segment.attrs.id || '',
+          type: segment.attrs.type,
+          slug: segment.attrs.slug,
+        };
+        const resolved = resolveObjectHtml?.(ref);
+        return resolved !== undefined ? resolved : defaultObjectHtml(ref);
+      }
+
+      const definition = definitions.get(segment.name);
+
+      // Paired = detached "Edit on page" instance: inline content (markdown).
+      let innerHtml: string;
+      if (segment.paired) {
+        innerHtml = renderMarkdown(segment.content || '');
+      } else if (!definition) {
+        return keepUnknown ? segment.raw : '';
+      } else if (definition.editor === 'plain') {
+        innerHtml = plainContentToHtml(definition.content);
+      } else if (definition.editor === 'html') {
+        innerHtml = definition.content || '';
+      } else {
+        innerHtml = renderMarkdown(definition.content || '');
+      }
+
+      return blockWrapper({
+        name: segment.name,
+        innerHtml,
+        definition,
+        attrs: segment.attrs,
+      });
+    })
+    .join('');
+}

--- a/packages/rich-text/test/renderToHtml.test.mjs
+++ b/packages/rich-text/test/renderToHtml.test.mjs
@@ -1,0 +1,81 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderToHtml } from '../dist/html.mjs';
+
+const blocks = [
+  {
+    name: 'cta',
+    title: 'Call to action',
+    editor: 'rich-text',
+    content: '## Ready?\n\n[Start](https://app.cosmicjs.com)',
+  },
+  { name: 'note', title: 'Note', editor: 'plain', content: 'a < b & c' },
+  { name: 'raw', title: 'Raw', editor: 'html', content: '<hr data-x="1">' },
+];
+
+test('renders prose markdown', () => {
+  const html = renderToHtml('Hello **world**');
+  assert.match(html, /<strong>world<\/strong>/);
+});
+
+test('synced reference resolves content from the block definition', () => {
+  const html = renderToHtml('{{cta /}}', { blocks });
+  assert.match(html, /class="cosmic-block cosmic-block-cta" data-block="cta"/);
+  assert.match(html, /Ready\?/);
+  assert.match(html, /href="https:\/\/app\.cosmicjs\.com"/);
+});
+
+test('detached (paired) block renders its inline content, not the definition', () => {
+  const html = renderToHtml('{{cta}}Local **copy** only{{/cta}}', { blocks });
+  assert.match(html, /class="cosmic-block cosmic-block-cta" data-block="cta"/);
+  assert.match(html, /Local <strong>copy<\/strong> only/);
+  // The definition content must NOT leak into a detached instance.
+  assert.doesNotMatch(html, /Ready\?/);
+});
+
+test('detached block works even without a matching definition', () => {
+  const html = renderToHtml('{{callout}}Just inline{{/callout}}', {
+    blocks,
+  });
+  assert.match(
+    html,
+    /class="cosmic-block cosmic-block-callout" data-block="callout"/
+  );
+  assert.match(html, /Just inline/);
+});
+
+test('plain and html block editors are honored for synced refs', () => {
+  const plain = renderToHtml('{{note /}}', { blocks });
+  assert.match(plain, /a &lt; b &amp; c/);
+  const raw = renderToHtml('{{raw /}}', { blocks });
+  assert.match(raw, /<hr data-x="1">/);
+});
+
+test('unknown synced block is kept verbatim by default', () => {
+  assert.equal(renderToHtml('{{missing /}}'), '{{missing /}}');
+  assert.equal(renderToHtml('{{missing /}}', { keepUnknown: false }), '');
+});
+
+test('object embeds use the default placeholder', () => {
+  const html = renderToHtml('{{object type="posts" id="abc" slug="hi" /}}');
+  assert.match(
+    html,
+    /class="cosmic-object" data-object="abc" data-object-type="posts"/
+  );
+  assert.match(html, />hi</);
+});
+
+test('object embeds can be resolved to custom HTML', () => {
+  const html = renderToHtml('{{object type="posts" id="abc" slug="hi" /}}', {
+    resolveObjectHtml: ({ id, slug }) => `<a href="/posts/${slug}">${id}</a>`,
+  });
+  assert.equal(html, '<a href="/posts/hi">abc</a>');
+});
+
+test('block attrs are passed to a custom blockWrapper', () => {
+  const html = renderToHtml('{{callout type="warning"}}Heads up{{/callout}}', {
+    blockWrapper: ({ name, innerHtml, attrs }) =>
+      `<aside class="${name} ${attrs.type || ''}">${innerHtml}</aside>`,
+  });
+  assert.match(html, /<aside class="callout warning"><p>Heads up<\/p>/);
+});

--- a/packages/rich-text/test/sdk-e2e.test.mjs
+++ b/packages/rich-text/test/sdk-e2e.test.mjs
@@ -1,0 +1,137 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  renderRichText,
+  renderToHtml,
+  DefaultBlock,
+  DefaultObjectBlock,
+} from '../dist/index.mjs';
+
+// A realistic value as the dashboard would store it: markdown prose, a synced
+// block reference, a detached ("Edit on page") block with inline content, a
+// synced plain-text block, a synced HTML block, and an inline object embed.
+const value = `# Cosmic
+
+Intro with **bold** text.
+
+{{cta /}}
+
+{{callout}}
+This copy is **unique** to this page.
+{{/callout}}
+
+{{legal /}}
+
+{{widget /}}
+
+Related post:
+
+{{object type="posts" id="p1" slug="hello-world" /}}
+`;
+
+const blocks = [
+  {
+    name: 'cta',
+    title: 'CTA',
+    editor: 'rich-text',
+    content: '## Ready?\n\n[Sign up](https://app.cosmicjs.com)',
+  },
+  { name: 'legal', title: 'Legal', editor: 'plain', content: 'Tom & Jerry <3' },
+  {
+    name: 'widget',
+    title: 'Widget',
+    editor: 'html',
+    content: '<iframe src="https://example.com"></iframe>',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// String renderer (@cosmicjs/rich-text/html)
+// ---------------------------------------------------------------------------
+
+test('renderToHtml renders a full document end to end', () => {
+  const html = renderToHtml(value, { blocks });
+
+  // Prose markdown.
+  assert.match(html, /<h1[^>]*>Cosmic<\/h1>/);
+  assert.match(html, /<strong>bold<\/strong>/);
+
+  // Synced rich-text block resolves from the definition.
+  assert.match(html, /cosmic-block cosmic-block-cta/);
+  assert.match(html, /Ready\?/);
+  assert.match(html, /href="https:\/\/app\.cosmicjs\.com"/);
+
+  // Detached block renders its inline content, not a definition.
+  assert.match(html, /cosmic-block cosmic-block-callout/);
+  assert.match(html, /This copy is <strong>unique<\/strong> to this page\./);
+
+  // Plain block is HTML-escaped; HTML block renders verbatim.
+  assert.match(html, /Tom &amp; Jerry &lt;3/);
+  assert.match(html, /<iframe src="https:\/\/example\.com"><\/iframe>/);
+
+  // Object embed placeholder.
+  assert.match(
+    html,
+    /cosmic-object" data-object="p1" data-object-type="posts"/
+  );
+});
+
+test('renderToHtml resolves object embeds when given a resolver', () => {
+  const html = renderToHtml(value, {
+    blocks,
+    resolveObjectHtml: ({ id, slug }) =>
+      `<a data-id="${id}" href="/posts/${slug}">read</a>`,
+  });
+  assert.match(html, /<a data-id="p1" href="\/posts\/hello-world">read<\/a>/);
+});
+
+// ---------------------------------------------------------------------------
+// React renderer (@cosmicjs/rich-text) - inspect the element tree (no DOM)
+// ---------------------------------------------------------------------------
+
+const nonNull = (nodes) => nodes.filter(Boolean);
+
+test('renderRichText returns React nodes for each segment', () => {
+  const nodes = nonNull(renderRichText(value, { blocks }));
+
+  const cta = nodes.find((n) => n.type === DefaultBlock && n.props.name === 'cta');
+  assert.ok(cta, 'cta block element present');
+  assert.match(cta.props.contentHtml, /Ready\?/);
+
+  const callout = nodes.find(
+    (n) => n.type === DefaultBlock && n.props.name === 'callout'
+  );
+  assert.ok(callout, 'detached callout element present');
+  // Inline content, rendered as markdown - not the (absent) definition.
+  assert.match(callout.props.contentHtml, /<strong>unique<\/strong>/);
+
+  const legal = nodes.find(
+    (n) => n.type === DefaultBlock && n.props.name === 'legal'
+  );
+  assert.match(legal.props.contentHtml, /Tom &amp; Jerry &lt;3/);
+
+  const obj = nodes.find((n) => n.type === DefaultObjectBlock);
+  assert.ok(obj, 'object embed element present');
+  assert.equal(obj.props.id, 'p1');
+  assert.equal(obj.props.type, 'posts');
+});
+
+test('renderRichText passes the resolved object to the component', () => {
+  const post = { id: 'p1', slug: 'hello-world', title: 'Hello World' };
+  const nodes = nonNull(
+    renderRichText(value, { blocks, resolveObject: ({ id }) => (id === 'p1' ? post : undefined) })
+  );
+  const obj = nodes.find((n) => n.type === DefaultObjectBlock);
+  assert.deepEqual(obj.props.object, post);
+});
+
+test('unknown synced blocks are dropped unless keepUnknown is set', () => {
+  const v = 'before {{nope /}} after';
+  const dropped = nonNull(renderRichText(v, { blocks }));
+  assert.ok(
+    !dropped.some((n) => n.type === DefaultBlock),
+    'no block element for unknown synced reference'
+  );
+  const kept = renderToHtml(v, { blocks });
+  assert.match(kept, /\{\{nope \/\}\}/);
+});


### PR DESCRIPTION
…ble blocks

This commit adds a new `renderToHtml` function in the `@cosmicjs/rich-text/html` entry point, allowing for rendering rich-text content to a plain HTML string without React dependencies. It also introduces support for editable blocks, enabling inline content editing with paired tokens. The package version is updated to 0.2.0, and relevant documentation is updated to reflect these changes.