### PR TITLE
fix(rich-text): revert manual version bump so release lands as 0.2.0

### DIFF
--- a/.cursor/rules/changesets-versioning.mdc
+++ b/.cursor/rules/changesets-versioning.mdc
@@ -1,0 +1,35 @@
+---
+description: How to version and release packages in this monorepo (Changesets)
+globs:
+  - "**/package.json"
+  - ".changeset/**"
+alwaysApply: true
+---
+
+# Versioning: never bump `version` by hand
+
+This repo releases with [Changesets](https://github.com/changesets/changesets). The
+version numbers in each `package.json` are owned by the automation, not by humans.
+
+## Rules
+
+- NEVER manually edit the `"version"` field in any `package.json`.
+- To ship a change, add a changeset instead: run `npx changeset` (or create a file
+  under `.changeset/`) describing the bump (`patch` | `minor` | `major`).
+- The `changeset-release/main` bot opens a "Version Packages" PR that consumes the
+  changeset, computes the next version from the **last published** version, updates
+  `CHANGELOG.md`, and deletes the changeset. Merging that PR publishes to npm.
+
+## Why this matters
+
+If you both bump `version` in `package.json` AND add a changeset, the bump is applied
+twice. Example incident: `@cosmicjs/rich-text` was manually bumped `0.1.0 -> 0.2.0`
+and also had a `minor` changeset, so the bot produced `0.3.0` instead of the intended
+`0.2.0`. The fix was to revert `package.json` back to the published baseline (`0.1.0`)
+and let the changeset alone bump it to `0.2.0`.
+
+## Checklist before committing a feature
+
+1. `package.json` `version` is unchanged from the published baseline.
+2. There is exactly one changeset describing the change, scoped to the right package(s).
+3. You did not hand-edit `CHANGELOG.md` (the bot writes it).

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmicjs/rich-text",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "Official renderer for Cosmic rich-text (markdown + shortcode blocks and inline object embeds): React components plus a framework-agnostic HTML string renderer.",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

`@cosmicjs/rich-text` was about to release as **0.3.0** when it should be **0.2.0**.

Root cause: commit `cb87173` (merged via #84) manually bumped `package.json` from `0.1.0` to `0.2.0` **and** added a `minor` changeset. The Changesets bot then applied the changeset on top of the manual bump (`0.2.0` + `minor` = `0.3.0`) in the "Version Packages" PR (#85).

This PR reverts the version on `main` back to the last published baseline (`0.1.0`) and keeps the changeset, so the bot recomputes the release as `0.1.0` -> `0.2.0`.

## Changes

- Revert `packages/rich-text/package.json` version `0.2.0` -> `0.1.0`. The `minor` changeset (`.changeset/rich-text-editable-and-html.md`) is untouched.
- Add `.cursor/rules/changesets-versioning.mdc` so versions are never hand-edited again (only changesets bump versions).

## After merge

The `changeset-release/main` bot will update PR #85 ("Version Packages") to bump `@cosmicjs/rich-text` to **0.2.0** instead of 0.3.0. Merge that PR to publish.

## Test plan

- [ ] Confirm PR #85 recomputes to `0.2.0` after this merges.
- [ ] Confirm `0.2.0` is the version published to npm (current `latest` is `0.1.0`).

Made with [Cursor](https://cursor.com)